### PR TITLE
Laravel 9 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 composer.lock
+.idea/

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,0 @@
-preset: laravel

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,6 @@
     ],
     "homepage": "https://github.com/stats4sd/laravel-sql-views",
     "keywords": ["Laravel", "Sql"],
-    "require": {
-        "illuminate/support": "~5|~6|~7|~8"
-    },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
         "mockery/mockery": "^1.1",


### PR DESCRIPTION
Very minor update; Only the dependencies are changed to allow this new version to run on Laravel 9.

When publishing a release, we should probably make it a major version update; going forward I think we can focus on only using PHP 8+ and Laravel 9+. 

