### PR TITLE
Add procs and functions

### DIFF
--- a/src/Commands/UpdateSqlViews.php
+++ b/src/Commands/UpdateSqlViews.php
@@ -71,12 +71,15 @@ class UpdateSqlViews extends Command
 
         foreach ($files as $file) {
 
-            $query = file_get_contents("{$dir_path}/{$file}");
+            if (Str::endsWith($file, '.sql')) {
 
-            $done = DB::statement($query);
+                $query = file_get_contents("{$dir_path}/{$file}");
 
-            if($done) {
-                $countProcs++;
+                $done = DB::statement($query);
+
+                if ($done) {
+                    $countProcs++;
+                }
             }
         }
     }
@@ -98,7 +101,7 @@ class UpdateSqlViews extends Command
                 $folder_files = scandir("{$dir_path}/{$file}");
 
                 // engage recursion...
-                $done = $this->processDir("{$dir_path}/{$file}");
+                $this->processDir("{$dir_path}/{$file}");
             }
         }
 

--- a/src/Commands/UpdateSqlViews.php
+++ b/src/Commands/UpdateSqlViews.php
@@ -71,7 +71,7 @@ class UpdateSqlViews extends Command
 
         foreach ($files as $file) {
 
-            $query = file_get_contents("${dir_path}/${file}");
+            $query = file_get_contents("{$dir_path}/{$file}");
 
             $done = DB::statement($query);
 
@@ -94,18 +94,18 @@ class UpdateSqlViews extends Command
 
         //iterate through subfolders and add to main set of files to check
         foreach ($files as $file) {
-            if (is_dir("${dir_path}/${file}") && $file != '.' && $file != '..') {
-                $folder_files = scandir("${dir_path}/${file}");
+            if (is_dir("{$dir_path}/{$file}") && $file != '.' && $file != '..') {
+                $folder_files = scandir("{$dir_path}/{$file}");
 
                 // engage recursion...
-                $done = $this->processDir("${dir_path}/${file}");
+                $done = $this->processDir("{$dir_path}/{$file}");
             }
         }
 
         //reset all views to "placeholder" views - to avoid problems when a view relies on another view that is not yet created;
         foreach ($files as $file) {
             if (Str::endsWith($file, '.sql')) {
-                $query = file_get_contents("${dir_path}/${file}");
+                $query = file_get_contents("{$dir_path}/{$file}");
                 $name = Str::replaceLast('.sql', '', $file);
 
                 $query = $this->makePlaceholderView($name, $query);
@@ -116,7 +116,7 @@ class UpdateSqlViews extends Command
         //Need to iterate through all the files twice, to avoid creating a "final" view before all "placeholder" views are created;
         foreach ($files as $file) {
             if (Str::endsWith($file, '.sql')) {
-                $query = file_get_contents("${dir_path}/${file}");
+                $query = file_get_contents("{$dir_path}/{$file}");
                 $name = Str::replaceLast('.sql', '', $file);
 
                 $done = $this->makeView($name, $query);
@@ -137,7 +137,7 @@ class UpdateSqlViews extends Command
      */
     public function makeView(string $name, string $query)
     {
-        $view = "CREATE OR REPLACE VIEW ${name} AS \n${query}";
+        $view = "CREATE OR REPLACE VIEW {$name} AS \n{$query}";
 
         return DB::statement($view);
     }
@@ -221,7 +221,7 @@ class UpdateSqlViews extends Command
 
         //now, define a placeholder view using the exact column-names to be used in the final view:
         $tempQuery = array_map(function ($item) {
-            return "1 AS `${item}`";
+            return "1 AS `{$item}`";
         }, $columnNames);
 
         $tempQueryStr = implode(', ', $tempQuery) . ';';

--- a/src/Commands/UpdateSqlViews.php
+++ b/src/Commands/UpdateSqlViews.php
@@ -75,7 +75,7 @@ class UpdateSqlViews extends Command
 
                 $query = file_get_contents("{$dir_path}/{$file}");
 
-                $done = DB::statement($query);
+                $done = DB::unprepared($query);
 
                 if ($done) {
                     $countProcs++;

--- a/src/SqlViewsServiceProvider.php
+++ b/src/SqlViewsServiceProvider.php
@@ -43,6 +43,11 @@ class SqlViewsServiceProvider extends ServiceProvider
             copy(__DIR__.'/database/views/example.sql', base_path('database/views/example.sql'));
         }
 
+        if (!is_dir(base_path('database/procedures'))) {
+            mkdir(base_path('database/procedures'));
+            copy(__DIR__ . '/database/procedures/example-proc.sql', base_path('database/views/example-proc.sql'));
+        }
+
         // Register the service the package provides.
         $this->app->singleton('sqlviews', function ($app) {
             return new SqlViews;

--- a/src/SqlViewsServiceProvider.php
+++ b/src/SqlViewsServiceProvider.php
@@ -45,7 +45,7 @@ class SqlViewsServiceProvider extends ServiceProvider
 
         if (!is_dir(base_path('database/procedures'))) {
             mkdir(base_path('database/procedures'));
-            copy(__DIR__ . '/database/procedures/example-proc.sql', base_path('database/views/example-proc.sql'));
+            copy(__DIR__ . '/database/procedures/example-proc.sql', base_path('database/procedures/example-proc.sql'));
         }
 
         // Register the service the package provides.

--- a/src/database/procedures/example-proc.sql
+++ b/src/database/procedures/example-proc.sql
@@ -1,4 +1,4 @@
-CREATE PROCEDURE `multiply`(IN num_one INT, IN num_two INT, OUT result OUT)
+CREATE PROCEDURE `multiply` (IN num_one INT, IN num_two INT, OUT result OUT)
 
 BEGIN
 

--- a/src/database/procedures/example-proc.sql
+++ b/src/database/procedures/example-proc.sql
@@ -1,0 +1,7 @@
+CREATE PROCEDURE `multiply`(IN num_one INT, IN num_two INT, OUT result OUT)
+
+BEGIN
+
+SET result = num_one * num_two;
+
+END

--- a/src/database/procedures/example-proc.sql
+++ b/src/database/procedures/example-proc.sql
@@ -1,3 +1,5 @@
+DROP PROCEDURE IF EXISTS `multiply`;
+
 CREATE PROCEDURE `multiply` (IN num_one INT, IN num_two INT, OUT result OUT)
 
 BEGIN


### PR DESCRIPTION
This PR adds the ability to run / update functions and procdures by including .sql script files inside the `database_path('procedures')` folder. 

- The `updatesql` artisan command is updated, so after it recreates the views based on queries inside the `database_path('views')` folder, it will run all .sql scripts inside the `procedures` folder. 
- When the package is first installed, it creates the `procedures` folder alongside the `views` folder, and includes an example function that creates a basic "multiply" mysql procedure. 

