### PR TITLE
fix example procedure

### DIFF
--- a/src/database/procedures/example-proc.sql
+++ b/src/database/procedures/example-proc.sql
@@ -1,6 +1,6 @@
 DROP PROCEDURE IF EXISTS `multiply`;
 
-CREATE PROCEDURE `multiply` (IN num_one INT, IN num_two INT, OUT result OUT)
+CREATE PROCEDURE `multiply` (IN num_one INT, IN num_two INT, OUT result INT)
 
 BEGIN
 


### PR DESCRIPTION
Error in example procedure means the whole thing doesn't run if you just install and then don't make changes. 