### PR TITLE
Swap proc/view creation order and fix bugs in proc step

### DIFF
--- a/src/Commands/UpdateSqlViews.php
+++ b/src/Commands/UpdateSqlViews.php
@@ -44,22 +44,20 @@ class UpdateSqlViews extends Command
      */
     public function handle()
     {
-        if (config('sqlviews.folder.create.views')) {
-            $countViews = $this->processDir(base_path('database/views'));
-            $this->info($countViews . ' views created');
-        }
-
         if (config('sqlviews.folder.create.procedures')) {
             $countProcs = $this->processProcsDir(base_path('database/procedures'));
             $this->info($countProcs . ' procedures run');
+        }
+
+        if (config('sqlviews.folder.create.views')) {
+            $countViews = $this->processDir(base_path('database/views'));
+            $this->info($countViews . ' views created');
         }
     }
 
     public function processProcsDir(string $dir_path)
     {
-
-        // process procs
-        $files = scandir(base_path('database/procedures'));
+        $files = scandir($dir_path);
         $countProcs = 0;
 
         //iterate through subfolders and add to main set of files to check
@@ -73,9 +71,7 @@ class UpdateSqlViews extends Command
         }
 
         foreach ($files as $file) {
-
             if (Str::endsWith($file, '.sql')) {
-
                 $query = file_get_contents("{$dir_path}/{$file}");
 
                 $done = DB::unprepared($query);
@@ -85,6 +81,8 @@ class UpdateSqlViews extends Command
                 }
             }
         }
+
+        return $countProcs;
     }
 
 

--- a/src/Commands/UpdateSqlViews.php
+++ b/src/Commands/UpdateSqlViews.php
@@ -66,7 +66,7 @@ class UpdateSqlViews extends Command
                 $folder_files = scandir("{$dir_path}/{$file}");
 
                 // engage recursion...
-                $this->processDir("{$dir_path}/{$file}");
+                $this->processProcsDir("{$dir_path}/{$file}");
             }
         }
 


### PR DESCRIPTION
The `processProcsDir` method should use the `$dir_path` passed to it and return the count.

Also, it's likely that the views make use of the procs, so create the procs first so the view create can succeed.

Lastly, the procs method should recurse with its own method, not the view method.